### PR TITLE
Update gems to latest heroku-18 supports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,14 +6,17 @@
 
 source "https://rubygems.org"
 
-ruby "3.2.2"
+ruby "3.2.2" # ruby 3.2.3 does NOT run on heroku-18!
 
-gem "mechanize", "~> 2.8.5"
-gem "nokogiri", "~> 1.16.5" # Latest version the platform supports
-gem "rake", "~> 12.3"
-gem "rspec", "~> 3.0"
-gem "rubocop"
+gem "mechanize", "~> 2.14"
+gem "nokogiri", "~> 1.17.2" # nokogiri 1.18 does NOT run on heroku-18!
 gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
-gem "simplecov", "~> 0.18.0"
-gem "simplecov-console"
-gem "sqlite3", "~> 1.6.3"
+gem "sqlite3", "~> 2.2.0" # sqlite3 2.3.0 does NOT run on heroku-18!
+
+group :development do
+  gem "rake", "~> 12.3"
+  gem "rspec", "~> 3.0"
+  gem "rubocop"
+  gem "simplecov", "~> 0.18.0"
+  gem "simplecov-console"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,28 +12,30 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    ansi (1.5.0)
+    ansi (1.6.0)
     ast (2.4.3)
     base64 (0.3.0)
-    connection_pool (2.5.3)
+    connection_pool (3.0.2)
     diff-lcs (1.6.2)
     docile (1.4.1)
     domain_name (0.6.20240107)
-    http-cookie (1.0.8)
+    http-cookie (1.1.6)
       domain_name (~> 0.5)
     httpclient (2.9.0)
       mutex_m
-    json (2.19.4)
-    language_server-protocol (3.17.0.5)
+    json (2.21.2)
+    language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
-    mechanize (2.8.5)
+    mechanize (2.14.0)
       addressable (~> 2.8)
+      base64
       domain_name (~> 0.5, >= 0.5.20190701)
       http-cookie (~> 1.0, >= 1.0.3)
-      mime-types (~> 3.0)
+      mime-types (~> 3.3)
       net-http-digest_auth (~> 1.4, >= 1.4.1)
       net-http-persistent (>= 2.5.2, < 5.0.dev)
+      nkf
       nokogiri (~> 1.11, >= 1.11.2)
       rubyntlm (~> 0.6, >= 0.6.3)
       webrick (~> 1.7)
@@ -41,25 +43,26 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0603)
+    mime-types-data (3.2026.0701)
     mutex_m (0.3.0)
     net-http-digest_auth (1.4.1)
-    net-http-persistent (4.0.6)
-      connection_pool (~> 2.2, >= 2.2.4)
-    nokogiri (1.16.8-aarch64-linux)
+    net-http-persistent (4.0.8)
+      connection_pool (>= 2.2.4, < 4)
+    nkf (0.3.0)
+    nokogiri (1.17.2-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.16.8-arm-linux)
+    nokogiri (1.17.2-arm-linux)
       racc (~> 1.4)
-    nokogiri (1.16.8-arm64-darwin)
+    nokogiri (1.17.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.8-x86-linux)
+    nokogiri (1.17.2-x86-linux)
       racc (~> 1.4)
-    nokogiri (1.16.8-x86_64-darwin)
+    nokogiri (1.17.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.8-x86_64-linux)
+    nokogiri (1.17.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.28.0)
-    parser (3.3.11.1)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     prism (1.9.0)
@@ -68,20 +71,20 @@ GEM
     rainbow (3.1.1)
     rake (12.3.3)
     regexp_parser (2.12.0)
-    rspec (3.13.1)
+    rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.4)
+    rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.5)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.4)
-    rubocop (1.86.1)
+    rspec-support (3.13.7)
+    rubocop (1.89.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -92,7 +95,7 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.1)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     ruby-progressbar (1.13.0)
@@ -101,17 +104,21 @@ GEM
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
-    simplecov-console (0.9.3)
+    simplecov-console (0.9.5)
       ansi
       simplecov
       terminal-table
-    simplecov-html (0.13.1)
-    sqlite3 (1.6.9-aarch64-linux)
-    sqlite3 (1.6.9-arm-linux)
-    sqlite3 (1.6.9-arm64-darwin)
-    sqlite3 (1.6.9-x86-linux)
-    sqlite3 (1.6.9-x86_64-darwin)
-    sqlite3 (1.6.9-x86_64-linux)
+    simplecov-html (0.13.2)
+    sqlite3 (2.2.0-aarch64-linux-gnu)
+    sqlite3 (2.2.0-aarch64-linux-musl)
+    sqlite3 (2.2.0-arm-linux-gnu)
+    sqlite3 (2.2.0-arm-linux-musl)
+    sqlite3 (2.2.0-arm64-darwin)
+    sqlite3 (2.2.0-x86-linux-gnu)
+    sqlite3 (2.2.0-x86-linux-musl)
+    sqlite3 (2.2.0-x86_64-darwin)
+    sqlite3 (2.2.0-x86_64-linux-gnu)
+    sqlite3 (2.2.0-x86_64-linux-musl)
     sqlite_magic (0.0.6)
       sqlite3
     terminal-table (4.0.0)
@@ -119,27 +126,35 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    webrick (1.9.1)
+    webrick (1.9.2)
     webrobots (0.1.2)
 
 PLATFORMS
   aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
   arm-linux
+  arm-linux-gnu
+  arm-linux-musl
   arm64-darwin
   x86-linux
+  x86-linux-gnu
+  x86-linux-musl
   x86_64-darwin
   x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
-  mechanize (~> 2.8.5)
-  nokogiri (~> 1.16.5)
+  mechanize (~> 2.14)
+  nokogiri (~> 1.17.2)
   rake (~> 12.3)
   rspec (~> 3.0)
   rubocop
   scraperwiki!
   simplecov (~> 0.18.0)
   simplecov-console
-  sqlite3 (~> 1.6.3)
+  sqlite3 (~> 2.2.0)
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,3 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+Bundler.require
+
 require "scraperwiki"
 require "mechanize"
 require "date"


### PR DESCRIPTION
## Description

Update gems to the latest versions supported by heroku-18 (morph.io's platform): mechanize ~> 2.14, nokogiri ~> 1.17.2, sqlite3 ~> 2.2.0. Move development/test gems (rake, rspec, rubocop, simplecov, simplecov-console) into `group :development` so morph.io only installs runtime gems. Add standalone header to scraper.rb (shebang, `frozen_string_literal`, `bundler/setup` + `Bundler.require`) so it runs directly.

## Motivation and Context

heroku-18 caps the gem versions morph.io can run (ruby 3.2.3, nokogiri 1.18 and sqlite3 2.3.0 all fail there). This applies the same pattern as the merged PRs planningalerts-scrapers/bawbaw#6, planningalerts-scrapers/banyule#10 and planningalerts-scrapers/multiple_technology_one#35, and replaces pending dependabot PRs.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
  - `bundle install` under ruby 3.2.2 via mise; `bundle lock --add-platform x86_64-linux` (lockfile carries x86_64-linux and `RUBY VERSION ruby 3.2.2p53`)
  - `bundle exec rubocop`: 9 pre-existing offences in code untouched by this change — left as-is
  - Local smoke run: scraper fetched and saved records successfully (13 public notices found, records saved)
- [ ] Ran automated tests on my own system (no specs in this repo)
- [ ] Confirmed it passed the GitHub actions tests (no workflows in this repo)

## Screenshots (if appropriate):

N/A

## Types of Changes

Dependency update — no functional change to scraping behaviour.
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
Note: a verification run on morph.io under a fork is advisable before merging.

Assisted-by: OpenCode/anthropic.claude-fable-5

